### PR TITLE
Fix: KubernetesRuntime _namespace attribute error

### DIFF
--- a/openhands/runtime/impl/kubernetes/kubernetes_runtime.py
+++ b/openhands/runtime/impl/kubernetes/kubernetes_runtime.py
@@ -1037,14 +1037,14 @@ class KubernetesRuntime(ActionExecutionClient):
             if coordinator and coordinator.enabled:
                 try:
                     pod_name = cls._get_pod_name(conversation_id)
-                    pod_key = f"k8s-pod:{cls._namespace}:{pod_name}"
+                    pod_key = f"k8s-pod:{namespace}:{pod_name}"
                     await coordinator.delete_resource_state(pod_key)
                     logger.debug(f'Cleaned up Redis state for conversation {conversation_id}')
                 except Exception as e:
                     logger.warning(f'Failed to clean up Redis state for conversation {conversation_id}: {e}')
 
             cls._cleanup_k8s_resources(
-                namespace=cls._namespace,
+                namespace=namespace,
                 remove_pvc=True,
                 conversation_id=conversation_id,
             )


### PR DESCRIPTION
This pull request includes a minor update to the `delete` method in `kubernetes_runtime.py`. The change ensures that the `namespace` parameter is used consistently instead of the class-level `cls._namespace` attribute.

Key change:

* [`openhands/runtime/impl/kubernetes/kubernetes_runtime.py`](diffhunk://#diff-4955595cf66c04ef046b20e89fcc725ebb8515cac0af1af6c234e66ffad697c0L1040-R1047): Updated the `delete` method to use the `namespace` parameter for constructing the `pod_key` and cleaning up Kubernetes resources, improving parameter consistency.